### PR TITLE
Update .drone.jsonnet

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,5 +1,5 @@
 local name = "jellyfin";
-local version = "10.9.3";
+local version = "10.9.11";
 local browser = "chrome";
 local platform = '22.02';
 local selenium = '4.21.0-20240517';


### PR DESCRIPTION
Latest stable jellyfin is 10.9.11, up from current syncloud 10.9.3. Receiving message in client app that this server update is required after next app update.