### PR TITLE
update to latest

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,5 +1,5 @@
 local name = "jellyfin";
-local version = "10.9.3";
+local version = "10.9.11";
 local browser = "chrome";
 local platform = '22.02';
 local selenium = '4.21.0-20240517';

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,5 +1,5 @@
 local name = "jellyfin";
-local version = "10.9.11";
+local version = "10.10.3";
 local browser = "chrome";
 local platform = '22.02';
 local selenium = '4.21.0-20240517';


### PR DESCRIPTION
Amazon firestick Jellyfin app banner stating update to at least 10.10.0 required to continue using app after next update. 